### PR TITLE
Refactor: Sửa vi phạm DRY – lặp lại kiểm tra priorityLevel

### DIFF
--- a/QLNVCN.java
+++ b/QLNVCN.java
@@ -71,18 +71,14 @@ public class PersonalTaskManagerViolations {
             System.out.println("Lỗi: Ngày đến hạn không hợp lệ. Vui lòng sử dụng định dạng YYYY-MM-DD.");
             return null;
         }
-        String[] validPriorities = {"Thấp", "Trung bình", "Cao"};
-        boolean isValidPriority = false;
-        for (String validP : validPriorities) {
-            if (validP.equals(priorityLevel)) {
-                isValidPriority = true;
-                break;
-            }
-        }
-        if (!isValidPriority) {
-            System.out.println("Lỗi: Mức độ ưu tiên không hợp lệ. Vui lòng chọn từ: Thấp, Trung bình, Cao.");
+        private static final Set<String> VALID_PRIORITIES = Set.of("Thấp", "Trung bình", "Cao");
+
+        // Dùng ở chỗ kiểm tra:
+        if (!VALID_PRIORITIES.contains(priorityLevel)) {
+            System.out.println("Lỗi: Mức độ ưu tiên không hợp lệ...");
             return null;
         }
+
 
         // Tải dữ liệu
         JSONArray tasks = loadTasksFromDb();


### PR DESCRIPTION
- Refactor đoạn kiểm tra mức độ ưu tiên để tránh lặp mã (vi phạm DRY).
- Thay thế mảng String và vòng lặp for bằng hằng số Set<String> VALID_PRIORITIES.
- Việc dùng Set giúp kiểm tra nhanh hơn (O(1)), code ngắn gọn hơn và dễ tái sử dụng trong các phần khác của chương trình.