### PR TITLE
Clean: Xoá thuộc tính recurrence_pattern chưa cần thiết (YAGNI)

### DIFF
--- a/QLNVCN.java
+++ b/QLNVCN.java
@@ -104,10 +104,6 @@ public class PersonalTaskManagerViolations {
         newTask.put("created_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
         newTask.put("last_updated_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
         newTask.put("is_recurring", isRecurring); // YAGNI: Thêm thuộc tính này dù chưa có chức năng xử lý nhiệm vụ lặp lại
-        if (isRecurring) {
-
-            newTask.put("recurrence_pattern", "Chưa xác định");
-        }
 
         tasks.add(newTask);
 


### PR DESCRIPTION
- Loại bỏ đoạn code thêm thuộc tính "recurrence_pattern" cho nhiệm vụ lặp lại.
- Hiện tại chưa có logic nào xử lý nhiệm vụ lặp lại, nên việc thêm thuộc tính này là thừa (vi phạm nguyên tắc YAGNI - You Aren't Gonna Need It).
- Giữ lại "is_recurring" để tránh lỗi nếu dữ liệu đã có, nhưng tránh mở rộng thêm khi chưa cần thiết.
- Giúp code gọn hơn, dễ bảo trì và đúng theo chức năng hiện tại của hệ thống.