### PR TITLE
Refactor: Đơn giản hóa định dạng ngày tạo theo nguyên tắc KISS

### DIFF
--- a/QLNVCN.java
+++ b/QLNVCN.java
@@ -101,7 +101,7 @@ public class PersonalTaskManagerViolations {
         newTask.put("due_date", dueDate.format(DATE_FORMATTER));
         newTask.put("priority", priorityLevel);
         newTask.put("status", "Chưa hoàn thành");
-        newTask.put("created_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
+        newTask.put("created_at", LocalDate.now().format(DATE_FORMATTER));
         newTask.put("last_updated_at", LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME));
         newTask.put("is_recurring", isRecurring); // YAGNI: Thêm thuộc tính này dù chưa có chức năng xử lý nhiệm vụ lặp lại
 


### PR DESCRIPTION
- Trước đây, giá trị "created_at" được gán bằng LocalDateTime.now().format(DateTimeFormatter.ISO_DATE_TIME), dẫn đến chuỗi ngày giờ quá dài với thông tin không cần thiết (giờ, phút, giây, múi giờ...).
- Để tuân thủ nguyên tắc KISS, đoạn mã đã được sửa để chỉ sử dụng LocalDate.now().format(DATE_FORMATTER), vì mục đích chỉ là lưu lại ngày tạo của task.
- Thay đổi giúp đơn giản hóa logic, cải thiện tính dễ đọc và giảm độ dài chuỗi lưu trữ.